### PR TITLE
MNT: regex compile raw string

### DIFF
--- a/relic/git.py
+++ b/relic/git.py
@@ -10,7 +10,7 @@ from . import PY3
 from . import ABBREV
 
 
-RE_GIT_DESC = re.compile('v?(.+?)-(\d+)-g(\w+)-?(.+)?')
+RE_GIT_DESC = re.compile(r"v?(.+?)-(\d+)-g(\w+)-?(.+)?")
 GitVersion = namedtuple('GitVersion',
                         ['pep386', 'short', 'long', 'date', 'dirty', 'commit',
                          'post'])


### PR DESCRIPTION
To get rid of deprecation warning in Python 3.6 tokenizer. This might throw an error straight out in Python 3.7 but I did not test the claim.

https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d